### PR TITLE
Add a workflow to upload artifacts on a new release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: build
 on:
   push:
   pull_request:
-  workflow_dispatch:
+  workflow_call:
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: release
+
+on:
+  release:
+    types: 
+      - published
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+
+  upload-release-assets:
+    runs-on: ubuntu-latest
+    needs: [build]
+    permissions:
+      contents: write
+      
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: HUDReplacer
+          path: HUDReplacer
+      - uses: actions/download-artifact@v4
+        with:
+          name: HUDReplacer.version
+      - run: tree
+
+      - name: Create Zip
+        run: |
+          cd HUDReplacer
+          zip -r9 ../HUDReplacer.zip *
+
+      - name: Upload Release Assets
+        run: |
+          gh release upload --clobber ${{ github.ref_name }}  \
+            HUDReplacer.zip                  \
+            HUDReplacer.version


### PR DESCRIPTION
HUDReplacer has no spacedock entry so there's no need to do anything more here than just upload artifacts to the release.