### PR TITLE
Release v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+## 1.3.0
+This is the first release from KSPModStewards/HUDReplacer. For previous changelog
+entries check out the releases on <https://github.com/UltraJohn/HUDReplacer>.
+
+### Added
+* HUDReplacer now has a `KSPAssembly` attribute.
+
+### Changed
+* @UltraJohn has relicensed HUDReplacer from ARR to GPLv3.

--- a/src/HUDReplacer/HUDReplacer.csproj
+++ b/src/HUDReplacer/HUDReplacer.csproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <Description>A mod that allows you to replace the HUD/UI of Kerbal Space Program</Description>
 
-        <Version>1.2.12</Version>
+        <Version>1.3.0</Version>
 
         <TargetFramework>net4.8</TargetFramework>
         <!-- <DebugType>portable</DebugType> -->


### PR DESCRIPTION
This is mostly just a release to test that the CI pipeline works.

## 1.3.0
This is the first release from KSPModStewards/HUDReplacer. For previous changelog entries check out the releases on <https://github.com/UltraJohn/HUDReplacer>.

### Added
* HUDReplacer now has a `KSPAssembly` attribute.

### Changed
* @UltraJohn has relicensed HUDReplacer from ARR to GPLv3.