### PR TITLE
Set GITHUB_TOKEN env var in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     types: 
       - published
 
+env:
+  GITHUB_TOKEN: ${{ github.token }}
+
 jobs:
   build:
     uses: ./.github/workflows/build.yml


### PR DESCRIPTION
Turns out that this is actually needed.