### PR TITLE
Release v1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 1.3.1
+### Changed
+* Optimized scene switch overhead down from 1.5s to 140ms (as tested with ZTheme).
+* Improved error messages when texture names are not in the appropriate format.
+
+### Fixed
+* Fixed a bunch of crashes if texture names were not in the expected format.
+
 ## 1.3.0
 This is the first release from KSPModStewards/HUDReplacer. For previous changelog
 entries check out the releases on <https://github.com/UltraJohn/HUDReplacer>.

--- a/src/HUDReplacer/HUDReplacer.csproj
+++ b/src/HUDReplacer/HUDReplacer.csproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <Description>A mod that allows you to replace the HUD/UI of Kerbal Space Program</Description>
 
-        <Version>1.3.0</Version>
+        <Version>1.3.1</Version>
 
         <TargetFramework>net4.8</TargetFramework>
         <!-- <DebugType>portable</DebugType> -->


### PR DESCRIPTION
## 1.3.1
### Changed
* Optimized scene switch overhead down from 1.5s to 140ms (as tested with ZTheme).
* Improved error messages when texture names are not in the appropriate format.

### Fixed
* Fixed a bunch of crashes if texture names were not in the expected format.